### PR TITLE
Adding a getting started section

### DIFF
--- a/src/getting-started/index.md
+++ b/src/getting-started/index.md
@@ -1,12 +1,34 @@
 # Getting Started
 
-Sections of this document contain several Rust examples you can just run in the
-online [Rust Playground](https://play.rust-lang.org/).
+## Rust Playground
 
-In case a full-fledged solution is needed, you can try out to setup an online
-available [sample project](https://github.com/microsoft/vscode-remote-try-rust)
-either directly in GitHub Codespaces or as a Visual Studio Code Dev Container.
+The easiest way to get started with Rust without needing any local
+installation is to use the [Rust Playground]. It is a minimal development
+front-end that runs in the Web browser and allows writing and running Rust
+code.
 
-This alternative is suggested to give you additional flexibility, in the case
-you would like to experiment with additional [cargo dependencies](#dependencies)
-like the ones needed in [code coverage](#code-coverage).
+## Dev Container
+
+The execution environment of the [Rust Playground] has some limitations, such
+as total compilation/execution time, memory and networking so another
+option that does not require installing Rust would be to use a _dev
+container_, such as the one provided in the repository
+<https://github.com/microsoft/vscode-remote-try-rust>. Like Rust Playground,
+the dev container can be run directly in a Web browser using [GitHub
+Codespaces] or [locally using Visual Studio Code][vscode-dev-containers].
+
+## Local Install
+
+For a complete local installation of Rust compiler and its development tools,
+see the [Installation] section of the [Getting Started] chapter in the [The
+Rust Programming Language][rs-book] book, or [the Install page] at
+[rust-lang.org].
+
+  [Rust Playground]: https://play.rust-lang.org/
+  [GitHub Codespaces]: https://github.com/features/codespaces
+  [vscode-dev-containers]: https://code.visualstudio.com/docs/devcontainers/containers
+  [rs-book]: https://doc.rust-lang.org/book/title-page.html
+  [Installation]: https://doc.rust-lang.org/book/ch01-01-installation.html
+  [Getting Started]: https://doc.rust-lang.org/book/ch01-00-getting-started.html
+  [the Install page]: https://www.rust-lang.org/tools/install
+  [rust-lang.org]: https://www.rust-lang.org/


### PR DESCRIPTION
This PR is adding a couple hints on how to get started for executing Rust examples in the document