### PR TITLE
Continuous deployment of rendered `mdBook` to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Publish to GitHub Pages
 
 on:
   push:
@@ -12,17 +12,18 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Install mdbook
+    - name: Install mdBook
       run: |
         mkdir mdbook
         curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.23/mdbook-v0.4.23-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
-    - name: Deploy GitHub Pages
+    - name: Build
+      run: mdbook build
+    - name: Deploy to GitHub Pages
       run: |
-        mdbook build
         git worktree add gh-pages gh-pages
-        git config user.name "Deploy from CI"
-        git config user.email ""
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         cd gh-pages
         rm -rf latest
         mkdir latest


### PR DESCRIPTION
Closes #8

Co-authored by @atifaziz 

With this PR we automatically deploy the rendered version from each commit to `main` to GitHub Pages.

Before merging:

- [x] Initialize a `gh-pages` branch