### PR TITLE
Remove authors from introduction

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -1,13 +1,5 @@
 # Introduction
 
-Authors:
-
-- Atif Aziz
-- Bastian Burger
-- Daniele Antonio Maggio
-- Dariusz Parys
-- Patrick Schuler
-
 This is a (non-comprehensive) guide for C# and .NET developers that are
 completely new to the Rust programming language. Some concepts and constructs
 translate fairly well between C#/.NET and Rust, but which may be expressed


### PR DESCRIPTION
With this PR we remove the authors from the introduction. The Git history is more adequate to track who authored what.