### PR TITLE
Add repo links, including for edits

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,3 +3,8 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Rust for .NET Developers"
+
+[output.html]
+git-repository-url = "https://github.com/microsoft/rust-for-dotnet-devs"
+git-repository-icon = "fa-github"
+edit-url-template = "https://github.com/microsoft/rust-for-dotnet-devs/edit/main/{path}"


### PR DESCRIPTION
This PR adds links to the top of each rendered page that points to the repo, including for contributing edits.