### PR TITLE
Remove residue from early draft outline

### DIFF
--- a/src/language/custom-types.md
+++ b/src/language/custom-types.md
@@ -664,13 +664,3 @@ impl Point {
     pub fn set_y(self, val: i32) -> Self { Self::new(self.x, val) }
 }
 ```
-
-- Overloading
-- Extension methods (extension traits)
-- Builder pattern
-- `System.Object` members:
-  - `Equals`
-  - `ToString` (`Display`, `Debug`)
-  - `GetHashCode`
-  - `GetType` (pattern-matching and enums)
-- Newtype (primitive obsession)


### PR DESCRIPTION
This PR removes some residue from an early draft outline.