### PR TITLE
Mention original authors in footnote

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -7,15 +7,15 @@ differently, whereas others are a radical departure, like memory management.
 This guide provides a brief comparison and mapping of those constructs and
 concepts with concise examples.
 
-The authors were themselves C#/.NET developers who were completely new to
-Rust. This guide is the compilation of the knowledge acquired by the authors
-writing Rust code over the course of several months. It is the guide the
-authors wish they had when they started on their Rust journey. That said, the
-authors would encourage you to read books and other material available on the
-Web to embrace Rust and its idioms rather than attempting to learn it
-exclusively through the lens of C# and .NET. Meanwhile, this guide can help
-answers some question quickly, like: _Does Rust support inheritance,
-threading, asynchronous programming, etc.?_
+The original authors[^authors] of this guide were themselves C#/.NET
+developers who were completely new to Rust. This guide is the compilation of
+the knowledge acquired by the authors writing Rust code over the course of
+several months. It is the guide the authors wish they had when they started on
+their Rust journey. That said, the authors would encourage you to read books
+and other material available on the Web to embrace Rust and its idioms rather
+than attempting to learn it exclusively through the lens of C# and .NET.
+Meanwhile, this guide can help answers some question quickly, like: _Does Rust
+support inheritance, threading, asynchronous programming, etc.?_
 
 Assumptions:
 
@@ -37,3 +37,14 @@ Non-goals:
 - While there are short examples that contrast C# and Rust code for some
   topics, this guide is not meant to be a cookbook of coding recipes in the
   two languages.
+
+---
+[^authors]: The original authors of this guide were (in alphabetical order):
+[Atif Aziz], [Bastian Burger], [Daniele Antonio Maggio], [Dariusz Parys] and
+[Patrick Schuler].
+
+  [Atif Aziz]: https://github.com/atifaziz
+  [Bastian Burger]: https://github.com/bastbu
+  [Daniele Antonio Maggio]: https://github.com/danigian
+  [Dariusz Parys]: https://github.com/dariuszparys
+  [Patrick Schuler]: https://github.com/p-schuler


### PR DESCRIPTION
In the introduction, it says _original authors_ in the following passage:

https://github.com/microsoft/rust-for-dotnet-devs/blob/a7b3b26d1acf195b77bf41b1aa56f4c716b18d48/src/introduction.md?plain=1#L10-L11

but there is no mention of them so this PR adds them to a footnote.