### PR TITLE
Pin markdown-link-check to 3.10.3 due to regression

### DIFF
--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -22,5 +22,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
-        npm install -g markdown-link-check
+        npm install -g markdown-link-check@3.10.3
         git ls-files -z '*.md' | xargs -0 -n1 markdown-link-check --config .markdownlinkcheck.jsonc


### PR DESCRIPTION
This PR pins markdown-link-check to version 3.10.3 due to the regression tcort/markdown-link-check#246 in the version 3.11.0 (latest at time of opening this PR). The regression causes [checks to fail](https://github.com/microsoft/rust-for-dotnet-devs/actions/runs/4622597522/jobs/8175560968#step:3:88) due to the following pattern being ignore and causing 404 (probably due to [crawlers policy on crates.io](https://crates.io/policies#crawlers)):

https://github.com/microsoft/rust-for-dotnet-devs/blob/3a2557516dc12af97074e5e355dbb97e25347805/.markdownlinkcheck.jsonc#L7
