### PR TITLE
Fixed broken link to structs in polymorphism.md

### DIFF
--- a/src/language/polymorphism.md
+++ b/src/language/polymorphism.md
@@ -10,8 +10,8 @@ See also:
 - [Generics][generics-section]
 - [Inheritance][inheritance-section]
 - [Operator overloading][operator-overloading-section]
-
-[structures-section]: ./custom-types.md#structures-struct
+  
+[structures-section]: ./custom-types/structs.md
 [generics-section]: ./generics.md
 [inheritance-section]: ./inheritance.md
 [operator-overloading-section]: ./operator-overloading.md

--- a/src/language/polymorphism.md
+++ b/src/language/polymorphism.md
@@ -10,6 +10,7 @@ See also:
 - [Generics][generics-section]
 - [Inheritance][inheritance-section]
 - [Operator overloading][operator-overloading-section]
+
 [structures-section]: ./custom-types/structs.md
 [generics-section]: ./generics.md
 [inheritance-section]: ./inheritance.md

--- a/src/language/polymorphism.md
+++ b/src/language/polymorphism.md
@@ -10,7 +10,6 @@ See also:
 - [Generics][generics-section]
 - [Inheritance][inheritance-section]
 - [Operator overloading][operator-overloading-section]
-  
 [structures-section]: ./custom-types/structs.md
 [generics-section]: ./generics.md
 [inheritance-section]: ./inheritance.md


### PR DESCRIPTION
While browsing the documentation I saw this little link error. I had time so I fixed it and helps other people to navigate