### PR TITLE
Fix link to generators in The Unstable Rust Book

### DIFF
--- a/src/linq/index.md
+++ b/src/linq/index.md
@@ -394,4 +394,4 @@ the developer having to write a full-blown class each time.
 _[Generators][generators.rs]_, as they're called in Rust, are still considered
 an unstable feature at the time of this writing.
 
-  [generators.rs]: https://doc.rust-lang.org/beta/unstable-book/language-features/generators.html
+  [generators.rs]: https://doc.rust-lang.org/stable/unstable-book/language-features/generators.html


### PR DESCRIPTION
This PR fixes a [broken link](https://github.com/microsoft/rust-for-dotnet-devs/actions/runs/6988317158/job/19015756868#step:3:390).