### PR TITLE
Skip link-check on `SECURITY.md`

### DIFF
--- a/.github/workflows/markdown-ci.yml
+++ b/.github/workflows/markdown-ci.yml
@@ -23,4 +23,6 @@ jobs:
     - uses: actions/checkout@v2
     - run: |
         npm install -g markdown-link-check@3.10.3
-        git ls-files -z '*.md' | xargs -0 -n1 markdown-link-check --config .markdownlinkcheck.jsonc
+        git ls-files '*.md' \
+        | grep -vE '^SECURITY\.md$' \
+        | xargs -n1 markdown-link-check --config .markdownlinkcheck.jsonc


### PR DESCRIPTION
The `SECURITY.md` is maintained externally so link checks can be skipped on it and shouldn't block the workflows here (which it does due to false negatives). This PR filter `SECURITY.md` from the list of files produced by `git ls-files`.