### PR TITLE
Fixed link in inheritance.md to structures

### DIFF
--- a/src/language/inheritance.md
+++ b/src/language/inheritance.md
@@ -6,5 +6,5 @@ making use of traits. However, similar to _interface inheritance_ in C#, Rust
 allows to define relationships between traits by using
 [_supertraits_][supertrait.rs].
 
-[structures]: ./custom-types.md#structures-struct
+[structures]: ./custom-types/structs.md
 [supertrait.rs]: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#using-supertraits-to-require-one-traits-functionality-within-another-trait


### PR DESCRIPTION
Fixed broken link in [inheritance.md](https://github.com/microsoft/rust-for-dotnet-devs/blob/b4d081673f449ff300e7b0508a35a265f4c4846e/src/language/inheritance.md) to structures.