### PR TITLE
Delete custom types orphan

### DIFF
--- a/src/language/custom-types.md
+++ b/src/language/custom-types.md
@@ -1,1 +1,0 @@
-# Custom Types

--- a/src/threading/synchronization.md
+++ b/src/threading/synchronization.md
@@ -97,4 +97,4 @@ chapter of the Rust book.
   [mutex guard]: https://doc.rust-lang.org/stable/std/sync/struct.MutexGuard.html
   [sync.rs]: https://doc.rust-lang.org/stable/std/marker/trait.Sync.html
   [send.rs]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html
-  [interfaces]: ../language/custom-types.md#interfaces
+  [interfaces]: ../language/custom-types/interfaces.md


### PR DESCRIPTION
This is a follow-up to PR #59 that removes a leftover from PR #19.
