### PR TITLE
use fs::write instead of file open and write in exception-handling

### DIFF
--- a/src/language/exception-handling.md
+++ b/src/language/exception-handling.md
@@ -119,8 +119,7 @@ In Rust, this is roughly equivalent to:
 
 ```rust
 fn write() {
-    match std::fs::File::create("temp.txt")
-        .and_then(|mut file| std::io::Write::write_all(&mut file, b"content"))
+    match std::fs::write("file.txt", b"content")?;
     {
         Ok(_) => {}
         Err(_) => println!("Writing to file failed."),
@@ -135,8 +134,7 @@ ergonomically:
 
 ```rust
 fn write() -> Result<(), std::io::Error> {
-    let mut file = std::fs::File::create("file.txt")?;
-    std::io::Write::write_all(&mut file, b"content")?;
+    std::fs::write("file.txt", b"content")?;
     Ok(())
 }
 ```


### PR DESCRIPTION
This removes the (advanced) `.and_then` combinator in favor of [`std::fs::write`](https://doc.rust-lang.org/std/fs/fn.write.html). 

This seems more in line with the dotnet writealltext code and the `and_then` will probably confuse and overload the target audience.