### PR TITLE
Add basic example for pattern matching on an option in rust

### DIFF
--- a/src/language/nullability-and-optionality.md
+++ b/src/language/nullability-and-optionality.md
@@ -36,6 +36,14 @@ if (max is { } someMax)
 
 You can use pattern matching to achieve the same behavior in Rust:
 
+```rust
+let max = Some(10u32);
+match max {
+    Some(max) => println!("The maximum is {}.", max), // The maximum is 10.
+    None => ()
+}
+```
+
 It would even be more concise to use `if let`:
 
 ```rust


### PR DESCRIPTION
There was a small missing example on the [nullability and optionality page](https://microsoft.github.io/rust-for-dotnet-devs/latest/language/nullability-and-optionality.html#control-flow-with-optionality), I went ahead and added it here.