### PR TITLE
Fix link to C# function pointer doc

### DIFF
--- a/src/language/lambda-and-closures.md
+++ b/src/language/lambda-and-closures.md
@@ -27,7 +27,7 @@ surrounding lexical scope, but not a function pointer. While C# also has
 [function pointers][*delegate] (`*delegate`), the managed and type-safe
 equivalent would be a static lambda expression.
 
-  [*delegate]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
+  [*delegate]: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/unsafe-code#function-pointers
 
 Functions and methods that accept closures are written with generic types that
 are bound to one of the traits representing functions: `Fn`, `FnMut` and


### PR DESCRIPTION
This PR fixes the link to C# function pointers documentation that had [gone dead](https://github.com/microsoft/rust-for-dotnet-devs/actions/runs/32261071823/job/96094200316?pr=73#step:3:288):

    FILE: src/language/lambda-and-closures.md
      [✖] https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
      [✓] https://doc.rust-lang.org/book/ch13-01-closures.html#moving-captured-values-out-of-closures-and-the-fn-traits
    
      2 links checked.